### PR TITLE
Refactor Trezor passphrase support without modifying connect Core

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bignumber": "^1.1.0",
     "borc": "^2.1.2",
     "cardano-crypto.js": "^5.3.6-rc.6",
-    "trezor-connect": "https://github.com/vacuumlabs/connect/releases/download/8.1.18-rc.1/trezor-connect-8.1.18-extended-rc.1.tgz"
+    "trezor-connect": "https://github.com/vacuumlabs/connect/releases/download/8.1.18-rc.2/trezor-connect-8.1.18-rc.2-extended.tgz"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.2.0",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -43,6 +43,7 @@ enum Errors {
   LedgerOperationError = 'Ledger operation error',
   InvalidAddressParametersProvidedError = 'Invalid address parameters provided',
   InvalidKeyGenInputsError = 'Invalid key gen inputs error',
+  TrezorPassphraseNotInsertableOnDevice = 'Trezor passphrase not insertable on the device',
 }
 
 export {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2322,14 +2322,14 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hd-wallet@9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/hd-wallet/-/hd-wallet-9.0.1.tgz#1607b023d8f4a8f7f8ccbdb3756a43d4929e6f85"
-  integrity sha512-MXeNdKRo7qOksA3kRWICbsz19n0aW5VD10XydnoxjRpC9MRv2ePl3GvgmvHoSCHnXFppXcmsXYUE6zGTWTVD1Q==
+hd-wallet@9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/hd-wallet/-/hd-wallet-9.1.0.tgz#0cfdae4e0d7147438c7802fedce29b7d049c0f5f"
+  integrity sha512-Oto94Q1e9C9wPsrxErky8TFoOqERiL6EZEo3jZ3BSPu36hpz1KfsB3MqPorvoOWQt6AjC5FoIy/lIPLx3aDMew==
   dependencies:
     "@trezor/utxo-lib" "0.1.1"
     bchaddrjs "^0.3.2"
-    bignumber.js "^9.0.0"
+    bignumber.js "^9.0.1"
     queue "^6.0.1"
     socket.io-client "^2.2.0"
 
@@ -4451,9 +4451,9 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-"trezor-connect@https://github.com/vacuumlabs/connect/releases/download/8.1.18-rc.1/trezor-connect-8.1.18-extended-rc.1.tgz":
-  version "8.1.18-extended"
-  resolved "https://github.com/vacuumlabs/connect/releases/download/8.1.18-rc.1/trezor-connect-8.1.18-extended-rc.1.tgz#0cbef80dd0b2fa754f7e38231f9a193abebaecaa"
+"trezor-connect@https://github.com/vacuumlabs/connect/releases/download/8.1.18-rc.2/trezor-connect-8.1.18-rc.2-extended.tgz":
+  version "8.1.18-rc.2-extended"
+  resolved "https://github.com/vacuumlabs/connect/releases/download/8.1.18-rc.2/trezor-connect-8.1.18-rc.2-extended.tgz#02f4d3d2786e1faa82e09f41ab958e59b32a4898"
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@trezor/blockchain-link" "^1.0.14"
@@ -4463,7 +4463,7 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     bignumber.js "^9.0.0"
     bowser "^2.11.0"
     events "^3.2.0"
-    hd-wallet "9.0.1"
+    hd-wallet "9.1.0"
     keccak "^3.0.1"
     node-fetch "^2.6.1"
     parse-uri "^1.0.3"


### PR DESCRIPTION
Motivation: The original implementation of passphrase support relied on modifications not present in the official version of trezor-connect. Based on a discussion with Trezor devs https://github.com/trezor/connect/issues/714 I found a way to achieve the same thing without tweaking the inner logic of trezor-connect, i.e. we will be able to directly use the official version of trezor connect once cardano owner support PR is merged and released.

Changes:
* Implemented custom listener on `UI.REQUEST_PASSPHRASE` TrezorConnect event which triggers the call to Trezor device to notify it that the passphrase would be inserted on it
* Switched from trezor-connect rc.1 to rc.2 which is the version of connect based on the latest code in the develop branch (with minor fixes by Trezor devs related to this functionality, see issue referenced above) of connect plus cardano owner support
* Refactored TrezorConnect initialization logic into a function as it got more complex
* Updated TrezorConnect manifest to comply with Trezor development guidelines: https://github.com/trezor/connect/blob/184d2d7c0cb7a7a2227d0feaecc3579e1357389c/docs/index.md#trezor-connect-manifest

Testing:
* `yarn test-integration-trezor` passes
* Tested manually deriving a public key with `yarn dev shelley address key-gen --path 1852H/1815H/0H/2/0 --verification-key-file stake1.vkey --hw-signing-file stake1.hwskey` and it requested the passphrase on the device, if it was set. When I disabled the passphrase, it also worked as expected (i.e. no passphrase prompt appeared on Trezor)