### PR TITLE
Update ledgerjs to fix public key export for ledger-app-cardano v2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/vacuumlabs/cardano-hw-cli#readme",
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@cardano-foundation/ledgerjs-hw-app-cardano": "https://github.com/vacuumlabs/ledgerjs-cardano-shelley/releases/download/bulk-export/cardano-foundation-ledgerjs-hw-app-cardano-2.0.2-rc.1.tgz",
+    "@cardano-foundation/ledgerjs-hw-app-cardano": "https://github.com/vacuumlabs/ledgerjs-cardano-shelley/releases/download/v2.0.2-rc.5/cardano-foundation-ledgerjs-hw-app-cardano-v2.0.2-rc.5.tgz",
     "@ledgerhq/hw-transport-node-hid": "^5.25.0",
     "argparse": "^2.0.1",
     "bignumber": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,9 +40,9 @@
   resolved "https://registry.yarnpkg.com/@calebboyd/semaphore/-/semaphore-1.3.1.tgz#4faa403d12f80e5d5c1d6e0d7916d048b6fa79cb"
   integrity sha512-17z9me12RgAEcMhIgR7f+BiXKbzwF9p1VraI69OxrUUSWGuSMOyOTEHQNVtMKuVrkEDVD0/Av5uiGZPBMYZljw==
 
-"@cardano-foundation/ledgerjs-hw-app-cardano@https://github.com/vacuumlabs/ledgerjs-cardano-shelley/releases/download/bulk-export/cardano-foundation-ledgerjs-hw-app-cardano-2.0.2-rc.1.tgz":
-  version "2.0.2-rc.1"
-  resolved "https://github.com/vacuumlabs/ledgerjs-cardano-shelley/releases/download/bulk-export/cardano-foundation-ledgerjs-hw-app-cardano-2.0.2-rc.1.tgz#91d7ca5108190f98685c2c559f6449e3b47797bd"
+"@cardano-foundation/ledgerjs-hw-app-cardano@https://github.com/vacuumlabs/ledgerjs-cardano-shelley/releases/download/v2.0.2-rc.5/cardano-foundation-ledgerjs-hw-app-cardano-v2.0.2-rc.5.tgz":
+  version "2.0.2-rc.5"
+  resolved "https://github.com/vacuumlabs/ledgerjs-cardano-shelley/releases/download/v2.0.2-rc.5/cardano-foundation-ledgerjs-hw-app-cardano-v2.0.2-rc.5.tgz#dcfcdd8994e4476b605701aa0ccbb81b665cde8c"
   dependencies:
     "@ledgerhq/hw-transport" "^5.12.0"
     babel-polyfill "^6.26.0"


### PR DESCRIPTION
Motivation: cardano-hw-cli uses the bulk public key export call for the ledger-app-cardano even for single keys which is fine, but given that it still uses a faulty version of ledgerjs that disables single key export for older ledger app version, it is not working properly with the currently released ledger app version which still does not support bulk public key export.

Changes: Update ledgerjs to the version with the single key export fix (done here: https://github.com/vacuumlabs/ledgerjs-cardano-shelley/pull/14) to enable the functionality for older ledger app version.

Testing:
* tested public key export both with ledger cardano app 2.0.4 (the one from ledger live) and the latest version from https://github.com/vacuumlabs/ledger-app-cardano-shelley/ with the command `yarn dev shelley address key-gen --path 1852H/1815H/0H/0/0 --hw-signing-file payment0-0.hwsfile --verification-key-file payment0-0.vkey`

closes #9 #16 