### PR TITLE
Update pool registration docs - clarify reward addr key and update signed tx assembly

### DIFF
--- a/docs/poolRegistration.md
+++ b/docs/poolRegistration.md
@@ -82,6 +82,8 @@ cardano-cli shelley stake-address build \
 
 creates a reward address, where all the pool rewards will go. Pool operator must then manually distribute these rewards between all the pool owners, if there are multiple of them.
 
+The staking key (`stake.vkey`) can either be managed from cardano-cli or cardano-hw-cli, and of course, the corresponding CLI then should be used to sign the transaction to withdraw the respective rewards. Also note that the reward address does not have to be witnessed when registering the stake pool, so you don't have to provide the corresponding staking signing key when registering the stake pool unless it's bound to an owner as well.
+
 Make sure you understand the structure and limitations of the stake pool's metadata and the stake pool registration certificate described [here](https://docs.cardano.org/projects/cardano-node/en/latest/stake-pool-operations/register_stakepool.html). It is crucial in the following blocks of commands.
 
 ## Get metadata hash
@@ -224,7 +226,7 @@ sudo cardano-hw-cli shelley transaction witness \
 Use witnesses from previous step to assemble the signed pool registration transaction
 
 ```
-cardano-cli shelley transaction sign-witness \
+cardano-cli shelley transaction assemble \
 --tx-body-file tx.raw \
 --witness-file operator.witness \
 --witness-file pool.witness \


### PR DESCRIPTION
Motivation: Clarify that reward address for stake pool can be managed from hw wallet as well and update the final tx assembly instruction to use the newer, less misleading version of the cardano-cli command.