### PR TITLE
Change Architecture from i386 to amd64 in deb-package control

### DIFF
--- a/scripts/build-linux-deb-package.sh
+++ b/scripts/build-linux-deb-package.sh
@@ -7,7 +7,7 @@ CARDANO_HW_CLI_PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk
 
 PACKAGE='cardano-hw-cli'
 VERSION=$CARDANO_HW_CLI_PACKAGE_VERSION'-1' # majorVersion.minorVersion.patchVersion-packageRevision
-ARCHITECTURE='i386'
+ARCHITECTURE='amd64'
 MAINTAINER='Peter Benc <peter.benc@vacuumlabs.com>, David Tran Duc <david.tran.duc@vacuumlabs.com>'
 DESCRIPTION='Cardano hw cli
  Command line tool for ledger/trezor transaction signing'


### PR DESCRIPTION
We already compile for a x64 target, users are seeing errors because the Control-Data is set to i386 in the deb-package. 
Changing the ARCHITECTURE from i386 to amd64 resolves this issue and presents a x64 package.