### PR TITLE
refactor cardano-crypto imports

### DIFF
--- a/src/crypto-providers/util.ts
+++ b/src/crypto-providers/util.ts
@@ -482,10 +482,6 @@ const ipv6ToString = (ipv6: Buffer | undefined): string | undefined => {
 
 const rewardAddressToPubKeyHash = (address: Buffer) => address.slice(1)
 
-const deviceVersionToStr = (
-  deviceVersion: DeviceVersion,
-): string => `${deviceVersion.major}.${deviceVersion.minor}.${deviceVersion.patch}`
-
 const isDeviceVersionGTE = (
   deviceVersion: DeviceVersion,
   thresholdVersion: DeviceVersion,
@@ -556,7 +552,6 @@ export {
   ipv4ToString,
   ipv6ToString,
   rewardAddressToPubKeyHash,
-  deviceVersionToStr,
   isDeviceVersionGTE,
   formatVotingRegistrationMetaData,
   areHwSigningDataNonByron,

--- a/src/transaction/guards.ts
+++ b/src/transaction/guards.ts
@@ -104,7 +104,7 @@ export const isTxMultiHostNameRelay = (
   return type === TxRelayTypes.MULTI_HOST_NAME && typeof dnsName === 'string'
 }
 
-const isMargin = (_value: any) => {
+const isPoolMargin = (_value: any) => {
   if (typeof _value !== 'object') return false
   const { tag, value } = _value
   if (!Array.isArray(value)) return false
@@ -142,7 +142,7 @@ export const isStakepoolRegistrationCert = (
     && Buffer.isBuffer(vrfPubKeyHash)
     && isUint64(pledge)
     && isUint64(cost)
-    && isMargin(margin)
+    && isPoolMargin(margin)
     && Buffer.isBuffer(rewardAddress)
     && isArrayOfType<Buffer>(poolOwnersPubKeyHashes, Buffer.isBuffer)
     && Array.isArray(relays)


### PR DESCRIPTION
Using `cardano.` helps me to immediately see that the functions are not ours (i.e. I would not think about refactoring them etc.).