### PR TITLE
Increase ledgerjs lib to 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/vacuumlabs/cardano-hw-cli#readme",
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@cardano-foundation/ledgerjs-hw-app-cardano": "^3.2.0",
+    "@cardano-foundation/ledgerjs-hw-app-cardano": "^3.2.1",
     "@ledgerhq/hw-transport-node-hid": "^5.25.0",
     "argparse": "^2.0.1",
     "bignumber": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,10 @@
   resolved "https://registry.yarnpkg.com/@calebboyd/semaphore/-/semaphore-1.3.1.tgz#4faa403d12f80e5d5c1d6e0d7916d048b6fa79cb"
   integrity sha512-17z9me12RgAEcMhIgR7f+BiXKbzwF9p1VraI69OxrUUSWGuSMOyOTEHQNVtMKuVrkEDVD0/Av5uiGZPBMYZljw==
 
-"@cardano-foundation/ledgerjs-hw-app-cardano@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-3.2.0.tgz#cca4bc70cf9747611629f2e8ac7d8bfe336cc608"
-  integrity sha512-YSdy/icwRP+5quL7FHFNDEE5IwyKZJQjydMRv3Ck7buKDiSz7g/Qa5w97KOLPU0R2oFf8jzktY+LZeXy/w1y4w==
+"@cardano-foundation/ledgerjs-hw-app-cardano@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@cardano-foundation/ledgerjs-hw-app-cardano/-/ledgerjs-hw-app-cardano-3.2.1.tgz#7c7539003eb9b60da33600715b03ac529738fe4b"
+  integrity sha512-qdYeXWDzHE6zEaQeajrKvop9D9mzGDta3OdzlYkFvjiMM0lr/VBLIkhPOd5t6I2vv/LnkhAY8izziVa+my+ifA==
   dependencies:
     "@ledgerhq/hw-transport" "^5.12.0"
     "@types/ledgerhq__hw-transport" "^4.21.3"


### PR DESCRIPTION
Updated to LedgerJS v3.2.1 with temporarily removed asset/policy ordering validation since it was causing problems for some people.