### PR TITLE
Require network id in every tx

### DIFF
--- a/src/commandExecutor.ts
+++ b/src/commandExecutor.ts
@@ -107,7 +107,7 @@ const CommandExecutor = async () => {
 
   const createSignedTx = async (args: ParsedTransactionSignArguments) => {
     const unsignedTxParsed = parseUnsignedTx(args.txBodyFileData.cborHex)
-    validateSigning(unsignedTxParsed, args.hwSigningFileData)
+    validateSigning(unsignedTxParsed, args.hwSigningFileData, args.network)
     const signedTx = await cryptoProvider.signTx(
       unsignedTxParsed, args.hwSigningFileData, args.network, args.changeOutputKeyFileData,
     )
@@ -126,7 +126,7 @@ const CommandExecutor = async () => {
 
   const createTxWitness = async (args: ParsedTransactionWitnessArguments) => {
     const unsignedTxParsed = parseUnsignedTx(args.txBodyFileData.cborHex)
-    validateWitnessing(unsignedTxParsed, args.hwSigningFileData)
+    validateWitnessing(unsignedTxParsed, args.hwSigningFileData, args.network)
     const txWitnesses = await cryptoProvider.witnessTx(
       unsignedTxParsed, args.hwSigningFileData, args.network, args.changeOutputKeyFileData,
     )

--- a/src/crypto-providers/util.ts
+++ b/src/crypto-providers/util.ts
@@ -300,8 +300,12 @@ const validateTxWithPoolRegistration = (
 }
 
 const validateWitnessing = (
-  unsignedTxParsed: _UnsignedTxParsed, signingFiles: HwSigningData[],
+  unsignedTxParsed: _UnsignedTxParsed, signingFiles: HwSigningData[], network: Network,
 ): void => {
+  if (unsignedTxParsed.networkId !== network.networkId) {
+    throw Error(Errors.NetworkIdMismatchError)
+  }
+
   if (!txHasStakePoolRegistrationCert(unsignedTxParsed.certificates)) {
     throw Error(Errors.CantWitnessTxWithoutPoolRegError)
   }
@@ -310,8 +314,12 @@ const validateWitnessing = (
 }
 
 const validateSigning = (
-  unsignedTxParsed: _UnsignedTxParsed, signingFiles: HwSigningData[],
+  unsignedTxParsed: _UnsignedTxParsed, signingFiles: HwSigningData[], network: Network,
 ): void => {
+  if (unsignedTxParsed.networkId !== network.networkId) {
+    throw Error(Errors.NetworkIdMismatchError)
+  }
+
   if (txHasStakePoolRegistrationCert(unsignedTxParsed.certificates)) {
     throw Error(Errors.CantSignTxWithPoolRegError)
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -93,7 +93,9 @@ const enum Errors {
   StakeCredentialsParseError = 'Failed to parse stake credentials',
   InvalidNativeScriptFile = 'Invalid native script file',
   Unreachable = 'Unreachable code reached',
-  InvalidScriptHashHex = 'Invalid script hash hex'
+  InvalidScriptHashHex = 'Invalid script hash hex',
+  NetworkIdParseError = 'Failed to parse transaction, network id is not a number',
+  NetworkIdMismatchError = 'Network id in transaction doesn\'t match with supplied network',
 }
 
 export {

--- a/src/transaction/txParser.ts
+++ b/src/transaction/txParser.ts
@@ -344,6 +344,14 @@ const parseMetaDataHash = (metaDataHash: any): Buffer | null => {
 
 const parseTxMint = (mint: any): _Mint => parseMultiAsset(mint, true)
 
+const parseNetworkId = (networkId: any): number => {
+  const parsedNetworkId = parseInt(networkId, 10)
+  if (Number.isNaN(parsedNetworkId)) {
+    throw Error(Errors.NetworkIdParseError)
+  }
+  return parsedNetworkId
+}
+
 const deconstructUnsignedTxDecoded = (unsignedTxDecoded: any): _UnsignedTxDecoded => {
   if (unsignedTxDecoded.length === 2) {
     const [txBody, meta] = unsignedTxDecoded
@@ -376,6 +384,7 @@ const parseUnsignedTx = (unsignedTxCborHex: UnsignedTxCborHex): _UnsignedTxParse
     const metaDataHash = parseMetaDataHash(txBody.get(TxBodyKeys.META_DATA_HASH))
     const validityIntervalStart = parseValidityIntervalStart(txBody.get(TxBodyKeys.VALIDITY_INTERVAL_START))
     const mint = parseTxMint(txBody.get(TxBodyKeys.MINT) || new Map())
+    const networkId = parseNetworkId(txBody.get(TxBodyKeys.NETWORK_ID))
 
     const getId = (): string => {
       const encodedTxBody = encodeCbor(txBody)
@@ -400,6 +409,7 @@ const parseUnsignedTx = (unsignedTxCborHex: UnsignedTxCborHex): _UnsignedTxParse
       validityIntervalStart,
       mint,
       scriptWitnesses,
+      networkId,
     }
   }
 }

--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -10,6 +10,7 @@ export enum TxBodyKeys {
   META_DATA_HASH = 7,
   VALIDITY_INTERVAL_START = 8,
   MINT = 9, // unsupported in current version
+  NETWORK_ID = 15,
 }
 
 export const enum TxWitnessKeys {
@@ -206,6 +207,7 @@ export type _UnsignedTxParsed = {
   validityIntervalStart: BigInt | null,
   mint: _Mint | null,
   scriptWitnesses: any[],
+  networkId: number,
 }
 
 export type _ByronWitness = {

--- a/test/integration/trezor/node/tx.js
+++ b/test/integration/trezor/node/tx.js
@@ -9,10 +9,10 @@ const { signingFiles } = require('./signingFiles')
 
 const transactions = {
   withInputAndOutput: {
-    // 97e0928d7f82f75e2917fddd07eeaaffaf2037ef07c9e1b0284337a3cfe4adcb
-    unsignedCborHex: '82a4008182582066001e24baf17637192d3a91c418cf4ed3c8053e333d0c35bd388deb2fa89c92000181825839013fc4aa3daffa8cc5275cd2d095a461c05903bae76aa9a5f7999613c58636aa540280a200e32f45e98013c24218a1a4996504634150dc55381a002b8a44021a0002b473031a00a2d750f6',
+    // 4a2b292d3dcc38b8930920b599ea6be9a4e3e9ae64fdc6ce8dd562d30a92fc9c
+    unsignedCborHex: '82a5008182582066001e24baf17637192d3a91c418cf4ed3c8053e333d0c35bd388deb2fa89c92000181825839013fc4aa3daffa8cc5275cd2d095a461c05903bae76aa9a5f7999613c58636aa540280a200e32f45e98013c24218a1a4996504634150dc55381a002b8a44021a0002b473031a00a2d7500f01f6',
     hwSigningFiles: [signingFiles.payment0],
-    signedTxCborHex: '83a4008182582066001e24baf17637192d3a91c418cf4ed3c8053e333d0c35bd388deb2fa89c92000181825839013fc4aa3daffa8cc5275cd2d095a461c05903bae76aa9a5f7999613c58636aa540280a200e32f45e98013c24218a1a4996504634150dc55381a002b8a44021a0002b473031a00a2d750a100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c158408141385df82ac9baa1699a2f3c0aff8eb1a0db3bf937e7c6942b20b00add410c3fac56c63d07a65e5d797f6c684c10e84e39ef412c775d7d98b353cb00231404f6',
+    signedTxCborHex: '83a5008182582066001e24baf17637192d3a91c418cf4ed3c8053e333d0c35bd388deb2fa89c92000181825839013fc4aa3daffa8cc5275cd2d095a461c05903bae76aa9a5f7999613c58636aa540280a200e32f45e98013c24218a1a4996504634150dc55381a002b8a44021a0002b473031a00a2d7500f01a100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c15840b301456c7cfb1a6bf4a2b6a579cd41029aa735ad118ce88a9f218cbc3920e787521acc113d045a966b733a70abbe53d9775ea3a3db5d52673fccdbaa966cb20ef6',
     network: 'MAINNET',
   },
   withDelegation: {
@@ -135,24 +135,26 @@ const transactions = {
 }
 
 async function testTxSigning(cryptoProvider, transaction) {
+  const network = NETWORKS[transaction.network]
   const unsignedTxParsed = parseUnsignedTx(transaction.unsignedCborHex)
-  validateSigning(unsignedTxParsed, transaction.hwSigningFiles)
+  validateSigning(unsignedTxParsed, transaction.hwSigningFiles, network)
   const signedTxCborHex = await cryptoProvider.signTx(
     unsignedTxParsed,
     transaction.hwSigningFiles,
-    NETWORKS[transaction.network],
+    network,
     [],
   )
   assert.deepStrictEqual(signedTxCborHex, transaction.signedTxCborHex)
 }
 
 async function testTxWitnessing(cryptoProvider, transaction) {
+  const network = NETWORKS[transaction.network]
   const unsignedTxParsed = parseUnsignedTx(transaction.unsignedCborHex)
-  validateWitnessing(unsignedTxParsed, transaction.hwSigningFiles)
+  validateWitnessing(unsignedTxParsed, transaction.hwSigningFiles, network)
   const witness = await cryptoProvider.witnessTx(
     unsignedTxParsed,
     transaction.hwSigningFiles,
-    NETWORKS[transaction.network],
+    network,
   )
   assert.deepStrictEqual(witness, transaction.witness)
 }


### PR DESCRIPTION
From now on, each transaction body will contain `network_id` (see https://github.com/vacuumlabs/trezor-firmware/pull/71).

TODO:
- decide what to do with files in `test/integration/trezor/cli` and test cases in `test/integration/trezor/node/tx.js` (currently, one test case is updated, but we're not sure if this is what we want to do)
- Ledger support