### PR TITLE
Fix for the "MissingPaymentKey" error for minting

### DIFF
--- a/src/crypto-providers/util.ts
+++ b/src/crypto-providers/util.ts
@@ -246,12 +246,13 @@ const validateTxWithoutPoolRegistration = (
   unsignedTxParsed: _UnsignedTxParsed, signingFiles: HwSigningData[],
 ): void => {
   const {
-    paymentSigningFiles, stakeSigningFiles, poolColdSigningFiles,
+    paymentSigningFiles, stakeSigningFiles, poolColdSigningFiles, mintSigningFiles, multisigSigningFiles,
   } = filterSigningFiles(signingFiles)
 
-  if (paymentSigningFiles.length === 0) {
+  if (paymentSigningFiles.length === 0 && mintSigningFiles.length === 0) {
     throw Error(Errors.MissingPaymentSigningFileError)
   }
+
 
   let numStakeWitnesses = unsignedTxParsed.withdrawals.length
   let numPoolColdWitnesses = 0


### PR DESCRIPTION
Thats a fast fix for the "Missing Payment Key" error when generating a witness with the mintSigningKey for token minting. The filter for mint and multisig was missing and the condition to throw the "Missing Payment" error did not include the presence of a mint key. Please recheck the code, i did a fast fix to test the token minting with a hw-key based policy, which worked afterall.