### PR TITLE
Add Alonzo era to envelope types

### DIFF
--- a/src/fileWriter.ts
+++ b/src/fileWriter.ts
@@ -36,6 +36,7 @@ const cardanoEraToSignedType: {[key in CardanoEra]: string} = {
   [CardanoEra.SHELLEY]: 'TxSignedShelley',
   [CardanoEra.ALLEGRA]: 'Tx AllegraEra',
   [CardanoEra.MARY]: 'Tx MaryEra',
+  [CardanoEra.ALONZO]: 'Tx AlonzoEra',
 }
 
 const constructSignedTxOutput = (era: CardanoEra, signedTxCborHex: SignedTxCborHex): SignedTxOutput => ({
@@ -49,6 +50,7 @@ const cardanoEraToWitnessType: {[key in CardanoEra]: string} = {
   [CardanoEra.SHELLEY]: 'TxWitnessShelley',
   [CardanoEra.ALLEGRA]: 'TxWitness AllegraEra',
   [CardanoEra.MARY]: 'TxWitness MaryEra',
+  [CardanoEra.ALONZO]: 'TxWitness AlonzoEra',
 }
 
 const constructTxWitnessOutput = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export enum CardanoEra {
   SHELLEY = 'Shelley',
   ALLEGRA = 'Allegra',
   MARY = 'Mary',
+  ALONZO = 'Alonzo',
 }
 
 export type CborHex = string & {


### PR DESCRIPTION
We encountered an issue on Adalite, where users provided txs that contained Alonzo envelope types. https://github.com/vacuumlabs/adalite/pull/1186

Same problem would apply here.