### PR TITLE
Refactor signing validation

### DIFF
--- a/src/commandExecutor.ts
+++ b/src/commandExecutor.ts
@@ -31,6 +31,7 @@ import {
   classifyPath,
   PathTypes,
   areHwSigningDataNonByron,
+  determineSigningMode,
 } from './crypto-providers/util'
 import { Errors } from './errors'
 import { parseOpCertIssueCounterFile } from './command-parser/parsers'
@@ -107,10 +108,14 @@ const CommandExecutor = async () => {
 
   const createSignedTx = async (args: ParsedTransactionSignArguments) => {
     const unsignedTxParsed = parseUnsignedTx(args.txBodyFileData.cborHex)
+    const signingParameters = {
+      signingMode: determineSigningMode(unsignedTxParsed, args.hwSigningFileData),
+      unsignedTxParsed,
+      hwSigningFileData: args.hwSigningFileData,
+      network: args.network,
+    }
     validateSigning(unsignedTxParsed, args.hwSigningFileData)
-    const signedTx = await cryptoProvider.signTx(
-      unsignedTxParsed, args.hwSigningFileData, args.network, args.changeOutputKeyFileData,
-    )
+    const signedTx = await cryptoProvider.signTx(signingParameters, args.changeOutputKeyFileData)
     write(args.outFile, constructSignedTxOutput(args.txBodyFileData.era, signedTx))
   }
 
@@ -127,10 +132,14 @@ const CommandExecutor = async () => {
 
   const createTxWitness = async (args: ParsedTransactionWitnessArguments) => {
     const unsignedTxParsed = parseUnsignedTx(args.txBodyFileData.cborHex)
+    const signingParameters = {
+      signingMode: determineSigningMode(unsignedTxParsed, args.hwSigningFileData),
+      unsignedTxParsed,
+      hwSigningFileData: args.hwSigningFileData,
+      network: args.network,
+    }
     validateWitnessing(unsignedTxParsed, args.hwSigningFileData)
-    const txWitnesses = await cryptoProvider.witnessTx(
-      unsignedTxParsed, args.hwSigningFileData, args.network, args.changeOutputKeyFileData,
-    )
+    const txWitnesses = await cryptoProvider.witnessTx(signingParameters, args.changeOutputKeyFileData)
     for (let i = 0; i < txWitnesses.length; i += 1) {
       write(args.outFiles[i], constructTxWitnessOutput(args.txBodyFileData.era, txWitnesses[i]))
     }

--- a/src/crypto-providers/ledgerCryptoProvider.ts
+++ b/src/crypto-providers/ledgerCryptoProvider.ts
@@ -169,16 +169,17 @@ export const LedgerCryptoProvider: () => Promise<CryptoProvider> = async () => {
 
   const prepareOutput = (
     output: _Output,
-    changeOutputFiles: HwSigningData[],
     network: Network,
+    changeOutputFiles: HwSigningData[],
+    signingMode: SigningMode,
   ): LedgerTypes.TxOutput => {
     const changeAddressParams = getAddressParameters(changeOutputFiles, output.address, network)
-    const amount = output.coins
     const tokenBundle = prepareTokenBundle(output.tokenBundle)
 
-    if (changeAddressParams) {
-      return prepareChangeOutput(amount, changeAddressParams, tokenBundle)
+    if (changeAddressParams && signingMode === SigningMode.ORDINARY_TRANSACTION) {
+      return prepareChangeOutput(output.coins, changeAddressParams, tokenBundle)
     }
+
     return {
       destination: {
         type: LedgerTypes.TxOutputDestinationType.THIRD_PARTY,
@@ -526,7 +527,7 @@ export const LedgerCryptoProvider: () => Promise<CryptoProvider> = async () => {
       (input, i) => prepareInput(signingMode, input, getSigningPath(paymentSigningFiles, i)),
     )
     const outputs = unsignedTxParsed.outputs.map(
-      (output) => prepareOutput(output, changeOutputFiles, network),
+      (output) => prepareOutput(output, network, changeOutputFiles, signingMode),
     )
     const certificates = unsignedTxParsed.certificates.map(
       (certificate) => prepareCertificate(

--- a/src/crypto-providers/signingValidation.ts
+++ b/src/crypto-providers/signingValidation.ts
@@ -1,0 +1,212 @@
+import { Errors } from '../errors'
+import {
+  TxCertificateKeys,
+  _UnsignedTxParsed,
+} from '../transaction/types'
+import {
+  SigningMode,
+  SigningParameters,
+} from './types'
+import {
+  filterSigningFiles,
+} from './util'
+
+const _countWitnessableItems = (unsignedTxParsed: _UnsignedTxParsed) => {
+  // we count stake registrations separately because they don't necessarily require a staking witness
+  let numStakeRegistrationItems = 0
+  let numStakeOtherItems = unsignedTxParsed.withdrawals.length
+  let numPoolColdItems = 0
+  unsignedTxParsed.certificates.forEach((cert) => {
+    switch (cert.type) {
+      case TxCertificateKeys.STAKING_KEY_REGISTRATION:
+        numStakeRegistrationItems += 1
+        break
+
+      case TxCertificateKeys.STAKING_KEY_DEREGISTRATION:
+      case TxCertificateKeys.DELEGATION:
+        numStakeOtherItems += 1
+        break
+
+      case TxCertificateKeys.STAKEPOOL_RETIREMENT:
+        numPoolColdItems += 1
+        break
+
+      default:
+        break
+    }
+  })
+  return { numStakeRegistrationItems, numStakeOtherItems, numPoolColdItems }
+}
+
+const validateOrdinaryWitnesses = (params: SigningParameters) => {
+  const {
+    poolColdSigningFiles, mintSigningFiles, multisigSigningFiles,
+  } = filterSigningFiles(params.hwSigningFileData)
+
+  const { numPoolColdItems } = _countWitnessableItems(params.unsignedTxParsed)
+
+  if (numPoolColdItems === 0 && poolColdSigningFiles.length > 0) {
+    throw Error(Errors.TooManyPoolColdSigningFilesError)
+  }
+  if (!params.unsignedTxParsed.mint && mintSigningFiles.length > 0) {
+    throw Error(Errors.TooManyMintSigningFilesError)
+  }
+  if (multisigSigningFiles.length > 0) {
+    throw Error(Errors.TooManyMultisigSigningFilesError)
+  }
+}
+
+const validateOrdinarySigning = (params: SigningParameters) => {
+  validateOrdinaryWitnesses(params)
+  // these checks should be performed only with createSignedTx call (when the signing file set is
+  // expected to be complete) on top of validateOrdinaryWitnesses
+
+  const {
+    paymentSigningFiles, stakeSigningFiles, poolColdSigningFiles,
+  } = filterSigningFiles(params.hwSigningFileData)
+
+  if (paymentSigningFiles.length === 0) {
+    throw Error(Errors.MissingPaymentSigningFileError)
+  }
+
+  const {
+    numStakeOtherItems, numPoolColdItems,
+  } = _countWitnessableItems(params.unsignedTxParsed)
+
+  if (numStakeOtherItems > 0 && (stakeSigningFiles.length === 0)) {
+    throw Error(Errors.MissingStakeSigningFileError)
+  }
+  if (numPoolColdItems > 0 && (poolColdSigningFiles.length === 0)) {
+    throw Error(Errors.MissingPoolColdSigningFileError)
+  }
+}
+
+const validatePoolOwnerWitnesses = (params: SigningParameters) => {
+  const {
+    paymentSigningFiles, stakeSigningFiles, poolColdSigningFiles, mintSigningFiles, multisigSigningFiles,
+  } = filterSigningFiles(params.hwSigningFileData)
+
+  if (paymentSigningFiles.length > 0) {
+    throw Error(Errors.TooManyPaymentFilesWithPoolRegError)
+  }
+
+  // we need exactly one signing file in order to unambiguously determine the owner to be witnessed
+  if (stakeSigningFiles.length === 0) {
+    throw Error(Errors.MissingStakeSigningFileError)
+  }
+  if (stakeSigningFiles.length > 1) {
+    throw Error(Errors.TooManyStakeSigningFilesError)
+  }
+
+  if (poolColdSigningFiles.length > 0) {
+    throw Error(Errors.TooManyPoolColdSigningFilesError)
+  }
+  if (mintSigningFiles.length > 0) {
+    throw Error(Errors.TooManyMintSigningFilesError)
+  }
+  if (multisigSigningFiles.length > 0) {
+    throw Error(Errors.TooManyMultisigSigningFilesError)
+  }
+}
+
+const validatePoolOperatorWitnesses = (params: SigningParameters) => {
+  const {
+    stakeSigningFiles, poolColdSigningFiles, mintSigningFiles, multisigSigningFiles,
+  } = filterSigningFiles(params.hwSigningFileData)
+
+  if (stakeSigningFiles.length > 0) {
+    throw Error(Errors.TooManyStakeSigningFilesError)
+  }
+  if (poolColdSigningFiles.length === 0) {
+    throw Error(Errors.MissingPoolColdSigningFileError)
+  }
+  if (poolColdSigningFiles.length > 1) {
+    throw Error(Errors.TooManyPoolColdSigningFilesError)
+  }
+  if (mintSigningFiles.length > 0) {
+    throw Error(Errors.TooManyMintSigningFilesError)
+  }
+  if (multisigSigningFiles.length > 0) {
+    throw Error(Errors.TooManyMultisigSigningFilesError)
+  }
+}
+
+const validateMultisigWitnesses = (params: SigningParameters) => {
+  const {
+    paymentSigningFiles, stakeSigningFiles, poolColdSigningFiles, mintSigningFiles,
+  } = filterSigningFiles(params.hwSigningFileData)
+
+  if (paymentSigningFiles.length > 0) {
+    throw Error(Errors.TooManyPaymentSigningFilesError)
+  }
+  if (stakeSigningFiles.length > 0) {
+    throw Error(Errors.TooManyStakeSigningFilesError)
+  }
+  if (poolColdSigningFiles.length > 0) {
+    throw Error(Errors.TooManyPoolColdSigningFilesError)
+  }
+  if (!params.unsignedTxParsed.mint && mintSigningFiles.length > 0) {
+    throw Error(Errors.TooManyMintSigningFilesError)
+  }
+}
+
+const validateMultisigSigning = (params: SigningParameters) => {
+  validateMultisigWitnesses(params)
+  // there are no checks that can be done (except those in validateMultisigWitnesses)
+}
+
+const validateWitnessing = (params: SigningParameters): void => {
+  // verifies whether the tx and signing files correspond to to each other and to the signing mode
+  if (params.unsignedTxParsed.inputs.length === 0) {
+    throw Error(Errors.MissingInputError)
+  }
+
+  switch (params.signingMode) {
+    case SigningMode.ORDINARY_TRANSACTION:
+      validateOrdinaryWitnesses(params)
+      break
+
+    case SigningMode.POOL_REGISTRATION_AS_OWNER:
+      validatePoolOwnerWitnesses(params)
+      break
+
+    case SigningMode.POOL_REGISTRATION_AS_OPERATOR:
+      validatePoolOperatorWitnesses(params)
+      break
+
+    case SigningMode.MULTISIG_TRANSACTION:
+      validateMultisigWitnesses(params)
+      break
+
+    default:
+      throw Error(Errors.Unreachable)
+  }
+}
+
+const validateSigning = (params: SigningParameters): void => {
+  if (params.unsignedTxParsed.inputs.length === 0) {
+    throw Error(Errors.MissingInputError)
+  }
+
+  switch (params.signingMode) {
+    case SigningMode.ORDINARY_TRANSACTION:
+      validateOrdinarySigning(params)
+      break
+
+    case SigningMode.POOL_REGISTRATION_AS_OWNER:
+    case SigningMode.POOL_REGISTRATION_AS_OPERATOR:
+      throw Error(Errors.CantSignTxWithPoolRegError)
+
+    case SigningMode.MULTISIG_TRANSACTION:
+      validateMultisigSigning(params)
+      break
+
+    default:
+      throw Error(Errors.Unreachable)
+  }
+}
+
+export {
+  validateSigning,
+  validateWitnessing,
+}

--- a/src/crypto-providers/trezorCryptoProvider.ts
+++ b/src/crypto-providers/trezorCryptoProvider.ts
@@ -211,11 +211,12 @@ const TrezorCryptoProvider: () => Promise<CryptoProvider> = async () => {
     output: _Output,
     network: Network,
     changeOutputFiles: HwSigningData[],
+    signingMode: SigningMode,
   ): TrezorTypes.CardanoOutput => {
     const changeAddressParams = getAddressParameters(changeOutputFiles, output.address, network)
     const tokenBundle = prepareTokenBundle(output.tokenBundle, false)
 
-    if (changeAddressParams) {
+    if (changeAddressParams && signingMode === SigningMode.ORDINARY_TRANSACTION) {
       return prepareChangeOutput(output.coins, changeAddressParams, tokenBundle)
     }
 
@@ -472,7 +473,7 @@ const TrezorCryptoProvider: () => Promise<CryptoProvider> = async () => {
       (input: _Input, i: number) => prepareInput(input, getSigningPath(paymentSigningFiles, i)),
     )
     const outputs = unsignedTxParsed.outputs.map(
-      (output: _Output) => prepareOutput(output, network, changeOutputFiles),
+      (output: _Output) => prepareOutput(output, network, changeOutputFiles, signingMode),
     )
     const certificates = unsignedTxParsed.certificates.map(
       (certificate: _Certificate) => prepareCertificate(certificate, stakeSigningFiles),

--- a/src/crypto-providers/types.ts
+++ b/src/crypto-providers/types.ts
@@ -18,6 +18,20 @@ import {
   NativeScriptDisplayFormat,
 } from '../types'
 
+export enum SigningMode {
+  ORDINARY_TRANSACTION,
+  POOL_REGISTRATION_AS_OWNER,
+  POOL_REGISTRATION_AS_OPERATOR,
+  MULTISIG_TRANSACTION,
+}
+
+export type SigningParameters = {
+  signingMode: SigningMode,
+  unsignedTxParsed: _UnsignedTxParsed,
+  hwSigningFileData: HwSigningData[],
+  network: Network,
+}
+
 export type CryptoProvider = {
   getVersion: () => Promise<string>,
   showAddress: (
@@ -28,15 +42,11 @@ export type CryptoProvider = {
     address: Address,
   ) => Promise<void>,
   signTx: (
-    unsignedTxParsed: _UnsignedTxParsed,
-    signingFiles: HwSigningData[],
-    network: Network,
+    params: SigningParameters,
     changeOutputFiles: HwSigningData[],
   ) => Promise<SignedTxCborHex>,
   witnessTx: (
-    unsignedTxParsed: _UnsignedTxParsed,
-    signingFiles: HwSigningData[],
-    network: Network,
+    params: SigningParameters,
     changeOutputFiles: HwSigningData[],
   ) => Promise<Array<_ShelleyWitness | _ByronWitness>>,
   getXPubKeys: (paths: BIP32Path[]) => Promise<XPubKeyHex[]>,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -26,6 +26,8 @@ const enum Errors {
   TooManyPaymentSigningFilesError = 'Too many payment signing files',
   TooManyStakeSigningFilesError = 'Too many stake signing files',
   TooManyPoolColdSigningFilesError = 'Too many pool cold key signing files',
+  TooManyMintSigningFilesError = 'Too many mint signing files',
+  TooManyMultisigSigningFilesError = 'Too many multisig signing files',
   MissingInputError = 'Missing input',
   MissingOutputError = 'Missing output',
   TrezorError = 'Trezor operation failed, please make sure you are using the latest version of Trezor firmware',
@@ -96,7 +98,6 @@ const enum Errors {
   StakeCredentialParseError = 'Failed to parse stake credentials',
   ScriptStakeCredentialInOrdinaryTx = 'Script stake credential used in an ordinary transaction',
   KeyHashStakeCredentialInMultisigTx = 'Address key hash stake credential used in a multisig transaction',
-  MixedOrdinaryAndMultisigSigningFiles = 'Mixed ordinary and multisig signing files',
   TrezorPoolRegistrationAsOperatorNotSupported = 'Trezor does not support signing pool registration certificate as operator',
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -97,6 +97,7 @@ const enum Errors {
   ScriptStakeCredentialInOrdinaryTx = 'Script stake credential used in an ordinary transaction',
   KeyHashStakeCredentialInMultisigTx = 'Address key hash stake credential used in a multisig transaction',
   MixedOrdinaryAndMultisigSigningFiles = 'Mixed ordinary and multisig signing files',
+  TrezorPoolRegistrationAsOperatorNotSupported = 'Trezor does not support signing pool registration certificate as operator',
 }
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ const executeCommand = async (): Promise<void> => {
       await commandExecutor.createTxPolicyId(parsedArgs)
       break
     case (CommandType.WITNESS_TRANSACTION):
-      await commandExecutor.createTxWitness(parsedArgs)
+      await commandExecutor.createTxWitnesses(parsedArgs)
       break
     case (CommandType.NODE_KEY_GEN):
       await commandExecutor.createNodeSigningKeyFiles(parsedArgs)

--- a/test/integration/ledger/node/tx.js
+++ b/test/integration/ledger/node/tx.js
@@ -3,11 +3,8 @@ const assert = require('assert')
 const { parseUnsignedTx } = require('../../../../src/transaction/txParser')
 const { LedgerCryptoProvider } = require('../../../../src/crypto-providers/ledgerCryptoProvider')
 const { NETWORKS } = require('../../../../src/constants')
-const {
-  determineSigningMode,
-  validateSigning,
-  validateWitnessing,
-} = require('../../../../src/crypto-providers/util')
+const { determineSigningMode } = require('../../../../src/crypto-providers/util')
+const { validateSigning, validateWitnessing } = require('../../../../src/crypto-providers/signingValidation')
 
 const { signingFiles } = require('./signingFiles')
 
@@ -264,7 +261,7 @@ async function testTxSigning(cryptoProvider, transaction) {
     hwSigningFileData: transaction.hwSigningFiles,
     network: NETWORKS[transaction.network],
   }
-  validateSigning(unsignedTxParsed, transaction.hwSigningFiles)
+  validateSigning(signingParameters)
   const signedTxCborHex = await cryptoProvider.signTx(signingParameters, [])
   assert.deepStrictEqual(signedTxCborHex, transaction.signedTxCborHex)
 }
@@ -278,7 +275,7 @@ async function testTxWitnessing(cryptoProvider, transaction) {
     hwSigningFileData: transaction.hwSigningFiles,
     network: NETWORKS[transaction.network],
   }
-  validateWitnessing(unsignedTxParsed, transaction.hwSigningFiles)
+  validateWitnessing(signingParameters)
   const witnesses = await cryptoProvider.witnessTx(signingParameters, [])
   assert.deepStrictEqual(witnesses, transaction.witnesses)
 }

--- a/test/integration/trezor/node/tx.js
+++ b/test/integration/trezor/node/tx.js
@@ -3,11 +3,8 @@ const assert = require('assert')
 const { parseUnsignedTx } = require('../../../../src/transaction/txParser')
 const { TrezorCryptoProvider } = require('../../../../src/crypto-providers/trezorCryptoProvider')
 const { NETWORKS } = require('../../../../src/constants')
-const {
-  determineSigningMode,
-  validateSigning,
-  validateWitnessing,
-} = require('../../../../src/crypto-providers/util')
+const { determineSigningMode } = require('../../../../src/crypto-providers/util')
+const { validateSigning, validateWitnessing } = require('../../../../src/crypto-providers/signingValidation')
 
 const { signingFiles } = require('./signingFiles')
 
@@ -187,7 +184,7 @@ async function testTxSigning(cryptoProvider, transaction) {
     hwSigningFileData: transaction.hwSigningFiles,
     network: NETWORKS[transaction.network],
   }
-  validateSigning(unsignedTxParsed, transaction.hwSigningFiles)
+  validateSigning(signingParameters)
   const signedTxCborHex = await cryptoProvider.signTx(signingParameters, [])
   assert.deepStrictEqual(signedTxCborHex, transaction.signedTxCborHex)
 }
@@ -201,7 +198,7 @@ async function testTxWitnessing(cryptoProvider, transaction) {
     hwSigningFileData: transaction.hwSigningFiles,
     network: NETWORKS[transaction.network],
   }
-  validateWitnessing(unsignedTxParsed, transaction.hwSigningFiles)
+  validateWitnessing(signingParameters)
   const witness = await cryptoProvider.witnessTx(signingParameters, [])
   assert.deepStrictEqual(witness, transaction.witness)
 }

--- a/test/integration/trezor/node/tx.js
+++ b/test/integration/trezor/node/tx.js
@@ -3,7 +3,11 @@ const assert = require('assert')
 const { parseUnsignedTx } = require('../../../../src/transaction/txParser')
 const { TrezorCryptoProvider } = require('../../../../src/crypto-providers/trezorCryptoProvider')
 const { NETWORKS } = require('../../../../src/constants')
-const { validateSigning, validateWitnessing } = require('../../../../src/crypto-providers/util')
+const {
+  determineSigningMode,
+  validateSigning,
+  validateWitnessing,
+} = require('../../../../src/crypto-providers/util')
 
 const { signingFiles } = require('./signingFiles')
 
@@ -176,24 +180,29 @@ const transactions = {
 
 async function testTxSigning(cryptoProvider, transaction) {
   const unsignedTxParsed = parseUnsignedTx(transaction.unsignedCborHex)
-  validateSigning(unsignedTxParsed, transaction.hwSigningFiles)
-  const signedTxCborHex = await cryptoProvider.signTx(
+  const signingMode = determineSigningMode(unsignedTxParsed, transaction.hwSigningFiles)
+  const signingParameters = {
+    signingMode,
     unsignedTxParsed,
-    transaction.hwSigningFiles,
-    NETWORKS[transaction.network],
-    [],
-  )
+    hwSigningFileData: transaction.hwSigningFiles,
+    network: NETWORKS[transaction.network],
+  }
+  validateSigning(unsignedTxParsed, transaction.hwSigningFiles)
+  const signedTxCborHex = await cryptoProvider.signTx(signingParameters, [])
   assert.deepStrictEqual(signedTxCborHex, transaction.signedTxCborHex)
 }
 
 async function testTxWitnessing(cryptoProvider, transaction) {
   const unsignedTxParsed = parseUnsignedTx(transaction.unsignedCborHex)
-  validateWitnessing(unsignedTxParsed, transaction.hwSigningFiles)
-  const witness = await cryptoProvider.witnessTx(
+  const signingMode = determineSigningMode(unsignedTxParsed, transaction.hwSigningFiles)
+  const signingParameters = {
+    signingMode,
     unsignedTxParsed,
-    transaction.hwSigningFiles,
-    NETWORKS[transaction.network],
-  )
+    hwSigningFileData: transaction.hwSigningFiles,
+    network: NETWORKS[transaction.network],
+  }
+  validateWitnessing(unsignedTxParsed, transaction.hwSigningFiles)
+  const witness = await cryptoProvider.witnessTx(signingParameters, [])
   assert.deepStrictEqual(witness, transaction.witness)
 }
 


### PR DESCRIPTION
Changes that we discussed should be implemented. The current validation performed on `createSignedTx` call should be roughly the same as before (and the `createTxWitness` validation is weaker).

I'm not sure whether we want to add a `validateMultisigWitnesses` function that would be similar to `validateOrdinaryWitnesses` (and why there is no such validation now).

Regarding variable/function names - maybe I don't quite understand hw-cli naming conventions if there are some, so please suggest improvements if you find something.