### PR TITLE
Other input and control forms

### DIFF
--- a/src/command-parser/commandParser.ts
+++ b/src/command-parser/commandParser.ts
@@ -18,6 +18,7 @@ export enum CommandType {
   SIGN_OPERATIONAL_CERTIFICATE = 'node.issue-op-cert',
   NODE_KEY_GEN = 'node.key-gen',
   CATALYST_VOTING_KEY_REGISTRATION_METADATA = 'catalyst.voting-key-registration-metadata',
+  PUBKEY_QUERY = 'pubkey.query',
 }
 
 const initParser = (parser: ArgumentParser | ArgumentGroup, config: any): void => {

--- a/src/command-parser/parserConfig.ts
+++ b/src/command-parser/parserConfig.ts
@@ -23,6 +23,17 @@ const derivationTypeArg = {
   },
 }
 
+const pubkeyArgs = {
+  '--path': {
+    required: true,
+    action: 'append',
+    type: (path: string) => parseBIP32Path(path),
+    dest: 'paths',
+    help: 'Derivation path to the key to sign with.',
+  },
+  ...derivationTypeArg,
+}
+
 const keyGenArgs = {
   '--path': {
     required: true,
@@ -183,6 +194,9 @@ export const parserConfig = {
         help: 'Output filepath of the verification key.',
       },
     },
+  },
+  'pubkey': {
+    'query': pubkeyArgs,
   },
 
   // ===============  commands taken from cardano-cli interface  ===============

--- a/src/command-parser/parserConfig.ts
+++ b/src/command-parser/parserConfig.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 /* eslint quote-props: ["error", "consistent"] */
 import {
+  extractHWSigningData,
   parseAddressFile,
   parseHwSigningFile,
   parseNetwork,
@@ -111,12 +112,18 @@ const txSigningArgs = {
       help: 'Input filepath of the tx. Use --cddl-format when building transactions with cardano-cli.',
     },
   },
-  '--hw-signing-file': {
-    dest: 'hwSigningFileData',
-    required: true,
-    action: 'append',
-    type: (path: string) => parseHwSigningFile(path),
-    help: 'Input filepath of the hardware wallet signing file.',
+  '_mutually-exclusive-group-required-signing-files': {
+    '--hw-signing-file': {
+      dest: 'hwSigningFileData',
+      action: 'append',
+      type: (path: string) => parseHwSigningFile(path),
+      help: 'Input filepath of the hardware wallet signing file.',
+    },
+    '--sign-request': {
+      type: (str: string) => JSON.parse(str).map((request) => extractHWSigningData(request)),
+      dest: 'hwSigningFileData',
+      help: 'JSON string with the hardware wallet signature request',
+    },
   },
   '--change-output-key-file': {
     dest: 'changeOutputKeyFileData',
@@ -124,6 +131,12 @@ const txSigningArgs = {
     default: [],
     type: (path: string) => parseHwSigningFile(path),
     help: 'Input filepath of change output file.',
+  },
+  '--out-file': {
+    required: true,
+    action: 'append',
+    dest: 'outFiles',
+    help: 'Output filepath.',
   },
   ...derivationTypeArg,
 }
@@ -264,15 +277,7 @@ export const parserConfig = {
       },
       ...derivationTypeArg,
     },
-    'witness': {
-      ...txSigningArgs,
-      '--out-file': {
-        required: true,
-        action: 'append',
-        dest: 'outFiles',
-        help: 'Output filepath.',
-      },
-    },
+    'witness': txSigningArgs,
     'validate-raw': {
       '--tx-body-file': {
         required: true,

--- a/src/command-parser/parsers.ts
+++ b/src/command-parser/parsers.ts
@@ -92,17 +92,25 @@ export const parseFileTypeMagic = (fileTypeMagic: string, pathType: PathTypes): 
   }
 }
 
-export const parseHwSigningFile = (path: string): HwSigningData => {
-  const data = JSON.parse(rw.readFileSync(path, 'utf8'))
-  data.path = parseBIP32Path(data.path)
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { type: fileTypeMagic, description, ...parsedData } = data
-
-  const result = { type: parseFileTypeMagic(fileTypeMagic, classifyPath(data.path)), ...parsedData }
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const extractHWSigningData = ({
+  type: fileTypeMagic, description, path: bip32pathstr, ...parsedData
+}: any): HwSigningData => {
+  const path = parseBIP32Path(bip32pathstr)
+  const result = {
+    type: parseFileTypeMagic(fileTypeMagic, classifyPath(path)),
+    path,
+    ...parsedData,
+  }
   if (isHwSigningData(result)) {
     return result
   }
   throw Error(Errors.InvalidHwSigningFileError)
+}
+
+export const parseHwSigningFile = (path: string): HwSigningData => {
+  const data = JSON.parse(rw.readFileSync(path, 'utf8'))
+  return extractHWSigningData(data)
 }
 
 export const parseRawTxFile = (path: string): RawTxFileData => {

--- a/src/commandExecutor.ts
+++ b/src/commandExecutor.ts
@@ -13,6 +13,7 @@ import {
 } from './fileWriter'
 import {
   ParsedShowAddressArguments,
+  ParsedPubkeyQueryArguments,
   ParsedAddressKeyGenArguments,
   ParsedTransactionSignArguments,
   ParsedTransactionPolicyIdArguments,
@@ -27,6 +28,7 @@ import {
 import { LedgerCryptoProvider } from './crypto-providers/ledgerCryptoProvider'
 import { TrezorCryptoProvider } from './crypto-providers/trezorCryptoProvider'
 import {
+  validBIP32Paths,
   validateKeyGenInputs,
   classifyPath,
   PathTypes,
@@ -78,6 +80,14 @@ const CommandExecutor = async () => {
     // eslint-disable-next-line no-console
     console.log(`address: ${args.address}`)
     return cryptoProvider.showAddress(args)
+  }
+
+  const printPubkeys = async ({ paths, derivationType }: ParsedPubkeyQueryArguments) => {
+    if (!validBIP32Paths(paths)) { throw Error(Errors.InvalidKeyGenInputsError) }
+
+    const xPubKeys = await cryptoProvider.getXPubKeys(paths, derivationType)
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(paths.map((path, index) => [path, xPubKeys[index]])))
   }
 
   const createSigningKeyFile = async (
@@ -285,6 +295,7 @@ const CommandExecutor = async () => {
   return {
     printDeviceVersion,
     showAddress,
+    printPubkeys,
     createSigningKeyFile,
     createVerificationKeyFile,
     createSignedTx,

--- a/src/crypto-providers/util.ts
+++ b/src/crypto-providers/util.ts
@@ -274,6 +274,7 @@ const determineSigningMode = (
     ? SigningMode.MULTISIG_TRANSACTION
     : SigningMode.ORDINARY_TRANSACTION
 }
+const validBIP32Paths = (paths: BIP32Path[]): boolean => Array.isArray(paths) && paths.every(isBIP32Path) && paths.length > 0
 
 const validateKeyGenInputs = (
   paths: BIP32Path[],
@@ -281,11 +282,9 @@ const validateKeyGenInputs = (
   verificationKeyFiles: string[],
 ): void => {
   if (
-    !Array.isArray(paths)
-    || !paths.every(isBIP32Path)
+    !validBIP32Paths
     || !Array.isArray(hwSigningFiles)
     || !Array.isArray(verificationKeyFiles)
-    || paths.length < 1
     || paths.length !== hwSigningFiles.length
     || paths.length !== verificationKeyFiles.length
   ) throw Error(Errors.InvalidKeyGenInputsError)
@@ -558,6 +557,7 @@ export {
   classifyPath,
   pathEquals,
   splitXPubKeyCborHex,
+  validBIP32Paths,
   validateKeyGenInputs,
   filterSigningFiles,
   findSigningPathForKeyHash,

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,9 @@ const executeCommand = async (): Promise<ExitCode> => {
     case (CommandType.SHOW_ADDRESS):
       await commandExecutor.showAddress(parsedArgs)
       break
+    case (CommandType.PUBKEY_QUERY):
+      await commandExecutor.printPubkeys(parsedArgs)
+      break
     case (CommandType.ADDRESS_KEY_GEN):
       await commandExecutor.createSigningKeyFile(parsedArgs)
       break

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,12 @@ export type ParsedShowAddressArguments = {
   derivationType?: DerivationType,
 }
 
+export type ParsedPubkeyQueryArguments = {
+  command: CommandType.PUBKEY_QUERY,
+  paths: BIP32Path[],
+  derivationType?: DerivationType,
+}
+
 export type ParsedAddressKeyGenArguments = {
   command: CommandType.ADDRESS_KEY_GEN,
   paths: BIP32Path[],
@@ -244,6 +250,7 @@ export type ParsedArguments =
   | ParsedAppVersionArguments
   | ParsedDeviceVersionArguments
   | ParsedShowAddressArguments
+  | ParsedPubkeyQueryArguments
   | ParsedAddressKeyGenArguments
   | ParsedVerificationKeyArguments
   | ParsedTransactionSignArguments


### PR DESCRIPTION
More than a pull request, I would like your opinion. I found this tool not entirely matching my workflow. I would rather call this tool from another one and pass JSON rather than so many input files. JSON is not practical for the command line, yet if it comes from another program there is no issue.

I have avoided making big changes to keep code compatibility. In this case I only have a request for the extended public keys at the account level, instead of the payment key level. I want to derive the keys in my tool and not every single time with this tool and generate a new file every time. Consequently when witnessing a transaction, I want to pass from my program a large JSON instead of individually specify each signing key file.

What do you think?