### PR TITLE
Check pubkey after signing

### DIFF
--- a/src/crypto-providers/util.ts
+++ b/src/crypto-providers/util.ts
@@ -43,6 +43,7 @@ const {
   base58,
   bech32,
   blake2b,
+  verify,
 } = require('cardano-crypto.js')
 
 export type _AddressParameters = {
@@ -705,6 +706,25 @@ const validateCIP36RegistrationAddressType = (addressType: number): void => {
 const getTxBodyHash = (txBody: TransactionBody): string =>
   blake2b(encodeTxBody(txBody), 32).toString('hex')
 
+const verifySignature = (
+  message: Buffer,
+  pubKey: Buffer,
+  signature: Buffer,
+): boolean => verify(message, pubKey, signature)
+
+const verifyIntendedPubKeySignatureMatch = (
+  messageHex: string,
+  hwSigningFile: HwSigningData,
+  signatureHex: string,
+): void => {
+  const hash = Buffer.from(messageHex, 'hex')
+  const pubKey = splitXPubKeyCborHex(hwSigningFile.cborXPubKeyHex).pubKey
+  const signature = Buffer.from(signatureHex, 'hex')
+  if (!verifySignature(hash, pubKey, signature)) {
+    throw Error(Errors.SigningPubKeyMismatchError)
+  }
+}
+
 export {
   PathTypes,
   classifyPath,
@@ -730,4 +750,5 @@ export {
   hasMultisigSigningFile,
   determineSigningMode,
   getTxBodyHash,
+  verifyIntendedPubKeySignatureMatch,
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -18,6 +18,7 @@ export const enum Errors {
   InvalidNodeKeyGenInputsError = 'Invalid node key-gen inputs',
   InvalidDerivationTypeError = 'Invalid derivation type',
   TxSerializationMismatchError = 'Tx serialization mismatch',
+  SigningPubKeyMismatchError = 'Signing public key mismatch: likely because an incorrect signing file was used',
   MetadataSerializationMismatchError = 'Metadata serialization mismatch',
   MissingHwSigningDataAtPathError = 'Can not find hw signing data by path',
   MissingHwSigningDataAtXPubKeyError = 'Can not find hw signing data by extended public key',
@@ -76,4 +77,5 @@ export const enum Errors {
   InvalidMessageAddressError = 'Cannot derive address parameters in message signing: likely because address signing files are missing',
   InvalidMessageAddressTypeError = 'Invalid or unsupported address type in message signing',
   InvalidMessageAddressSigningFilesError = 'Missing address signing files in message signing',
+  MessageAddressMismatchError = 'Message address mismatch: likely because incorrect address signing files were used',
 }


### PR DESCRIPTION
Adds a sanity check of:
- tx witness signature vs. the pubkey in hw signing file,
- message signing pubkey derived on device vs. the pubkey in hw signing file,
- message signing address field derived on device vs. the address provided on command line.