### PR TITLE
fix: sed -i requires an empty string argument ('') on macOS. Please u…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cardano-hw-cli",
   "version": "1.16.0-rc.1",
-  "commit": "2706bbbd672f8318dcd2ee95682259f3537590b1",
+  "commit": "e7225d91e0ddc6152ad973ba803d6c016cb14d7e",
   "description": "Cardano CLI tool for hardware wallets",
   "author": "Vacuumlabs",
   "homepage": "https://github.com/vacuumlabs/cardano-hw-cli#readme",

--- a/scripts/build-common.sh
+++ b/scripts/build-common.sh
@@ -9,4 +9,10 @@ yarn build-js
 
 # Update commit hash in package.json
 COMMIT_HASH=$(git rev-parse HEAD)
-sed -i '/"commit":.*,/d' package.json && sed -i '4 i \  "commit": "'${COMMIT_HASH}'",\' package.json
+
+# print commit hash
+echo "Commit hash: ${COMMIT_HASH}"
+
+sed -i '' '/"commit":.*,/d' package.json && sed -i '' '4 i \
+  "commit": "'${COMMIT_HASH}'",\
+' package.json


### PR DESCRIPTION
sed -i requires an empty string argument ('') on macOS. Please use 'sudo yarn build-macos' to build.