### PR TITLE
fix: fix dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@ngraveio/bc-ur": "^1.1.13",
     "@trezor/connect": "9.4.5",
     "argparse": "^2.0.1",
+    "bech32": "^2.0.0",
     "bignumber": "^1.1.0",
     "cardano-crypto.js": "^6.1.2",
     "cardano-hw-interop-lib": "^3.0.2",

--- a/src/crypto-providers/keystoneUtils.ts
+++ b/src/crypto-providers/keystoneUtils.ts
@@ -16,8 +16,7 @@ import {UR, UREncoder, URDecoder} from '@ngraveio/bc-ur'
 import {Actions, TransportHID} from '@keystonehq/hw-transport-usb'
 import {throwTransportError, Status} from '@keystonehq/hw-transport-error'
 import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs'
-// @ts-expect-error cardano-crypto.js is not typed
-import bech32 from 'cardano-crypto.js'
+import {bech32} from 'bech32'
 import KeystoneSDK, {
   CardanoCatalystRequestProps,
   CardanoSignCip8MessageData,


### PR DESCRIPTION
We need to use the functions provided by bech32, which don't exist in cardano-crypto.js, so we need to make modifications.