### PR TITLE
Expose built binaries from CI, fix outdated hw interop lib version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,24 @@ commands:
       - run: sudo corepack enable
       - run: yarn install
 
+  setup_macos:
+    steps:
+      - checkout
+      - run:
+          name: Set up Node and Yarn
+          command: |
+            set -ex
+            brew install node@22
+            echo 'export PATH="/opt/homebrew/opt/node@22/bin:$PATH"' >> "$BASH_ENV"
+            node --version
+            corepack enable
+            yarn --version
+      - run:
+          name: Install dependencies
+          command: |
+            set -ex
+            yarn install
+
 jobs:
   audit:
     <<: *defaults
@@ -38,6 +56,28 @@ jobs:
       - run: yarn build-js
       - run: yarn test-unit
       - run: yarn test-bin
+      - store_artifacts:
+          path: build/release
+          destination: release-binaries
+
+  build_macos_artifacts:
+    macos:
+      xcode: "16.4.0"
+    resource_class: m4pro.medium
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - setup_macos
+      - run:
+          name: Build macOS artifacts
+          no_output_timeout: 45m
+          command: |
+            set -ex
+            ./scripts/build-macos-all.sh
+            ls -la build/release/
+      - store_artifacts:
+          path: build/release
+          destination: macos-release-binaries
 
 workflows:
   version: 2
@@ -46,3 +86,4 @@ workflows:
       - audit
       - lint
       - build_and_test
+      - build_macos_artifacts

--- a/.cspell.json
+++ b/.cspell.json
@@ -27,6 +27,7 @@
     "cbor",
     "chsh",
     "cimg",
+    "codesign",
     "concats",
     "COSE",
     "cryptoprovider",

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ yarn dev ...
 
 __NOTE: The pre-compiled `HID.node` binaries in `build/dependencies/` must match the target Node version and architecture. After updating Node, these may need to be rebuilt for each target platform.__
 
+macOS `.tar.gz` artifacts must be built **on macOS** (`yarn build-macos-all` or `yarn build-macos-arm64`). CI builds the **native** architecture only (arm64 on Apple Silicon runners). Build `yarn build-macos-x64` on an Intel Mac for the x64 tarball. `pkg` ad-hoc signs the main executable; the build scripts sign `HID.node` separately. Linux cross-compiled macOS pkg binaries fail at runtime (`UNEXPECTED-20`). Do not re-sign release binaries with `codesign --deep` — it corrupts the embedded pkg snapshot.
+
 Install node version v20 (LTS)
 ```
 nvm i 20
@@ -201,6 +203,7 @@ yarn build-linux-deb
 yarn build-linux-tar
 yarn build-linux-tar-arm64
 yarn build-windows
+yarn build-macos-all
 yarn build-macos-x64
 yarn build-macos-arm64
 ```

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   },
   "scripts": {
     "build": "./scripts/build-all.sh",
+    "build-linux-all": "./scripts/build-linux-all.sh",
+    "build-macos-all": "./scripts/build-macos-all.sh",
     "build-linux-deb": "./scripts/build-common.sh && ./scripts/build-linux-deb-package.sh",
     "build-linux-tar": "./scripts/build-common.sh && ./scripts/build-linux-x64-tar-gz.sh",
     "build-linux-tar-arm64": "./scripts/build-common.sh && ./scripts/build-linux-arm64-tar-gz.sh",
@@ -29,7 +31,7 @@
     "prettier": "prettier --write .",
     "spell:check": "yarn cspell lint --gitignore '**' 2>/dev/null",
     "test-unit": "mocha -r ts-node/register 'test/unit/**/*.ts'",
-    "test-bin": "yarn build && ./build/linux/archive-x64/cardano-hw-cli/cardano-hw-cli --help",
+    "test-bin": "yarn build-linux-all && ./build/linux/archive-x64/cardano-hw-cli/cardano-hw-cli --help",
     "test-integration-ledger": "mocha -r ts-node/register 'test/integration/ledger/node/**/*.ts' --exit",
     "test-integration-ledger-speculos": "LEDGER_TRANSPORT=speculos yarn test-integration-ledger",
     "test-integration-trezor": "mocha -r ts-node/register 'test/integration/trezor/node/**/*.ts' --exit",

--- a/scripts/build-linux-all.sh
+++ b/scripts/build-linux-all.sh
@@ -9,22 +9,10 @@ cd ..
 ./scripts/build-linux-arm64-tar-gz.sh
 ./scripts/build-windows.sh
 
-if [[ "$(uname -s)" == "Darwin" ]]; then
-  MAC_ARCH="$(uname -m)"
-  if [[ "${MAC_ARCH}" == "arm64" ]]; then
-    ./scripts/build-macos-arm64.sh
-  elif [[ "${MAC_ARCH}" == "x86_64" ]]; then
-    ./scripts/build-macos-x64.sh
-  fi
-else
-  echo "Skipping macOS artifacts (build on macOS — Linux cross-compiled pkg binaries fail at runtime)."
-fi
-
 rm -R build/release 2> /dev/null
-mkdir build/release
+mkdir -p build/release
 
 find ./build/linux -name '*.deb' -exec cp {} ./build/release \;
 find ./build/linux -name '*.tar.gz' -exec cp {} ./build/release \;
-find ./build/macos -name '*.tar.gz' -exec cp {} ./build/release \;
 find ./build/windows -name '*.zip' -exec cp {} ./build/release \;
 cp ./scripts/autocomplete.sh ./build/release/autocomplete.sh

--- a/scripts/build-macos-all.sh
+++ b/scripts/build-macos-all.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+cd ${0%/*}
+cd ..
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "macOS artifacts must be built on macOS (Linux cross-compiled pkg binaries are broken at runtime)." >&2
+  exit 1
+fi
+
+./scripts/build-common.sh
+
+MAC_ARCH="$(uname -m)"
+if [[ "${MAC_ARCH}" == "arm64" ]]; then
+  echo "Building macOS arm64 artifacts (native architecture)."
+  ./scripts/build-macos-arm64.sh
+elif [[ "${MAC_ARCH}" == "x86_64" ]]; then
+  echo "Building macOS x64 artifacts (native architecture)."
+  ./scripts/build-macos-x64.sh
+else
+  echo "Unsupported macOS architecture: ${MAC_ARCH}" >&2
+  exit 1
+fi
+
+mkdir -p build/release
+find ./build/macos -name '*.tar.gz' -exec cp {} ./build/release \;

--- a/scripts/build-macos-arm64.sh
+++ b/scripts/build-macos-arm64.sh
@@ -1,24 +1,31 @@
 #!/bin/bash
-# This script can be run from linux and executable should be runnable on macos
+# Build macOS arm64 artifacts. Must run on macOS (see build-macos-all.sh).
+
+set -euo pipefail
 
 cd ${0%/*}
 cd ..
 
 CARDANO_HW_CLI_PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[", ]//g')
 
+ARTIFACT_DIR=./build/macos/archive-arm64/cardano-hw-cli
+
 # Remove old build
-rm -R ./build/macos/archive-arm64 2> /dev/null
+rm -rf ./build/macos/archive-arm64
 
 # Prepare directories
-mkdir ./build/macos 2> /dev/null
-mkdir ./build/macos/archive-arm64
-mkdir ./build/macos/archive-arm64/cardano-hw-cli
+mkdir -p ./build/macos/archive-arm64
+mkdir -p "${ARTIFACT_DIR}"
 
-# Build executable
-yarn pkg ./dist/index.js -o ./build/macos/archive-arm64/cardano-hw-cli/cardano-hw-cli -c package.json -t node22-macos-arm64 --options "no-warnings=ExperimentalWarning"
+# pkg ad-hoc signs the main executable on macOS by default
+yarn pkg ./dist/index.js -o "${ARTIFACT_DIR}/cardano-hw-cli" -c package.json -t node22-macos-arm64 --options "no-warnings=ExperimentalWarning"
 
-# Copy dependencies
-cp -R ./build/dependencies/macos-arm64/* ./build/macos/archive-arm64/cardano-hw-cli/
+# Copy native deps (pkg does not sign bundled .node files)
+cp -R ./build/dependencies/macos-arm64/* "${ARTIFACT_DIR}/"
+
+if [[ -f "${ARTIFACT_DIR}/HID.node" ]]; then
+  codesign -s - --force "${ARTIFACT_DIR}/HID.node"
+fi
 
 # Archive
 cd ./build/macos/archive-arm64

--- a/scripts/build-macos-x64.sh
+++ b/scripts/build-macos-x64.sh
@@ -1,24 +1,31 @@
 #!/bin/bash
-# This script can be run from linux and executable should be runnable on macos
+# Build macOS x64 artifacts. Must run on an Intel Mac (pkg cannot build x64 on Apple Silicon).
+
+set -euo pipefail
 
 cd ${0%/*}
 cd ..
 
 CARDANO_HW_CLI_PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[", ]//g')
 
+ARTIFACT_DIR=./build/macos/archive-x64/cardano-hw-cli
+
 # Remove old build
-rm -R ./build/macos/archive-x64 2> /dev/null
+rm -rf ./build/macos/archive-x64
 
 # Prepare directories
-mkdir ./build/macos 2> /dev/null
-mkdir ./build/macos/archive-x64
-mkdir ./build/macos/archive-x64/cardano-hw-cli
+mkdir -p ./build/macos/archive-x64
+mkdir -p "${ARTIFACT_DIR}"
 
-# Build executable
-yarn pkg ./dist/index.js -o ./build/macos/archive-x64/cardano-hw-cli/cardano-hw-cli -c package.json -t node22-macos-x64 --options "no-warnings=ExperimentalWarning"
+# pkg ad-hoc signs the main executable on macOS by default
+yarn pkg ./dist/index.js -o "${ARTIFACT_DIR}/cardano-hw-cli" -c package.json -t node22-macos-x64 --options "no-warnings=ExperimentalWarning"
 
-# Copy dependencies
-cp -R ./build/dependencies/macos-x64/* ./build/macos/archive-x64/cardano-hw-cli/
+# Copy native deps (pkg does not sign bundled .node files)
+cp -R ./build/dependencies/macos-x64/* "${ARTIFACT_DIR}/"
+
+if [[ -f "${ARTIFACT_DIR}/HID.node" ]]; then
+  codesign -s - --force "${ARTIFACT_DIR}/HID.node"
+fi
 
 # Archive
 cd ./build/macos/archive-x64


### PR DESCRIPTION
* expose build artifact (binaries) from CI

How to test: check that artifacts shown in CI work for you